### PR TITLE
Fix react-native crash.

### DIFF
--- a/fetch-npm-browserify.js
+++ b/fetch-npm-browserify.js
@@ -3,5 +3,5 @@
 //
 // Return that as the export for use in Webpack, Browserify etc.
 require('whatwg-fetch');
-var globalObj = self || this.self || this;
+var globalObj = typeof self !== 'undefined' && self || this;
 module.exports = globalObj.fetch.bind(globalObj);


### PR DESCRIPTION
The "self" variable is undefined in the React Native environment, which causes fetch-everywhere to crash. A typeof check has been added to fix the crash.
